### PR TITLE
Remove unnecessary (and problematic) dependencies from the gwt-compatible pom

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -40,12 +40,6 @@
             <groupId>org.gwtproject.safecss</groupId>
             <artifactId>gwt-safecss</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.gwt</groupId>
-                    <artifactId>gwt-user</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.gwtproject.regexp</groupId>
@@ -71,52 +65,6 @@
             <groupId>org.gwtproject.callback</groupId>
             <artifactId>gwt-callback</artifactId>
             <version>HEAD-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auto</groupId>
-            <artifactId>auto-common</artifactId>
-            <version>${auto.common.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons.codec.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.w3c.css</groupId>
-            <artifactId>sac</artifactId>
-            <version>${sac.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.closure-stylesheets</groupId>
-            <artifactId>closure-stylesheets</artifactId>
-            <version>${closure-stylesheets.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-dev</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- class LocaleInfo-->
-        <dependency>
-            <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-user</artifactId>
-            <version>${gwt.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This was a quick pass to simplify the things out that neither j2cl nor gwt2 should attempt to compile.